### PR TITLE
Fixed issue with crawler.

### DIFF
--- a/app/static/coffee/app.coffee
+++ b/app/static/coffee/app.coffee
@@ -7,7 +7,7 @@ class CrawlForm extends Backbone.View
         data_model.prop "disabled", true
 
     crawler.change ->
-        if crawler.val() == 'achenyu'
+        if crawler.val() == 'ache'
             data_model.prop "disabled", false
         else
             data_model.prop "disabled", true

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -20,7 +20,7 @@ CrawlForm = (function(_super) {
   };
 
   crawler.change(function() {
-    if (crawler.val() === 'achenyu') {
+    if (crawler.val() === 'ache') {
       return data_model.prop("disabled", false);
     } else {
       return data_model.prop("disabled", true);


### PR DESCRIPTION
Simple fix. Javascript relied on the field being named "achenyu", but the field was renamed to "ache". Run crawl depended the name of the crawler being "ache" but in the database it was "achenyu". 
