### PR TITLE
More vagrant fixes, saltier Docker interaction, better celery, removing redis from conda install

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -72,14 +72,6 @@ Vagrant.configure(2) do |config|
     salt.run_highstate = true
   end
 
-$bootstrap = <<SCRIPT
-  sudo apt-get update
-  sudo apt-get install git
-  source /vagrant/deploy/deploy_vagrant.sh
-SCRIPT
-  
-# config.vm.provision "bootstrap", type: "shell", inline: $bootstrap
-
 $app = <<SCRIPT
   cd /vagrant/source/
   echo "MEMEX-EXPLORER IS NOW RUNNING, POINT YOUR BROWSER TO: http://localhost:8000"

--- a/environment.yml
+++ b/environment.yml
@@ -15,7 +15,6 @@ dependencies:
     - pip
     - sphinx
     - jinja2
-    - redis
     - redis-py
     - pip:
         - docker-compose

--- a/salt/roots/salt/docker.sls
+++ b/salt/roots/salt/docker.sls
@@ -3,4 +3,6 @@ docker.io:
     - installed
 
 docker-py:
-  pip.installed
+  pip.installed:
+    - name: docker-py == 0.5.0
+    - reload_modules: True

--- a/salt/roots/salt/docker.sls
+++ b/salt/roots/salt/docker.sls
@@ -1,3 +1,6 @@
 docker.io:
   pkg:
     - installed
+
+docker-py:
+  pip.installed

--- a/salt/roots/salt/memex-explorer.sls
+++ b/salt/roots/salt/memex-explorer.sls
@@ -63,25 +63,22 @@ create_apps:
   file.copy:
     - source: /home/vagrant/miniconda/envs/memex/bin/docker-compose
 
-docker-containers:
-  cmd.run:
-    - name: |
-         docker pull elasticsearch
-         docker pull continuumio/tika
-         docker pull continuumio/kibana
-    - require:
-        - pkg: docker.io
+elasticsearch:
+  docker.pulled:
+    - tag: latest
 
-redis-server:
-  cmd.run:
-    - name: /sbin/start-stop-daemon --chuid vagrant --background --oknodo --start --exec /home/vagrant/miniconda/envs/memex/bin/redis-server
-    - cwd: /vagrant/source
-    - require:
-        - sls: conda-memex
+continuumio/tika:
+  docker.pulled:
+    - tag: latest
+
+continuumio/kibana:
+  docker.pulled:
+    - tag: latest
 
 celery:
   cmd.run:
-    - name: /sbin/start-stop-daemon --chuid vagrant --background --oknodo --start --exec /home/vagrant/miniconda/envs/memex/bin/celery  -- --workdir="/vagrant/source" -A memex worker
+    - name: /home/vagrant/miniconda/envs/memex/bin/celery --detach --workdir="/vagrant/source" -A memex worker
     - cwd: /vagrant/source
+    - user: vagrant
     - require:
         - sls: conda-memex

--- a/salt/roots/salt/pip.sls
+++ b/salt/roots/salt/pip.sls
@@ -1,0 +1,3 @@
+python-pip:
+  pkg:
+    - installed

--- a/salt/roots/salt/redis-server.sls
+++ b/salt/roots/salt/redis-server.sls
@@ -1,0 +1,9 @@
+install-redis-server:
+  pkg.installed:
+    - name: redis-server
+
+run-redis-server:
+  service.running:
+    - name: redis-server
+    - require:
+        - pkg: redis-server

--- a/salt/roots/salt/top.sls
+++ b/salt/roots/salt/top.sls
@@ -3,6 +3,7 @@ base:
     - pkgrepo.managed:
       - ppa: keithw/mosh
     - nginx
+    - redis-server
     - git
     - silversearcher-ag
     - docker

--- a/salt/roots/salt/top.sls
+++ b/salt/roots/salt/top.sls
@@ -5,6 +5,7 @@ base:
     - nginx
     - redis-server
     - git
+    - pip
     - silversearcher-ag
     - docker
     - tig


### PR DESCRIPTION
(No merge please)

This pulls redis out from conda dependencies and makes it a system dependency.  I know there's a bit of a philosophical argument here about whether we should be using conda to install services like redis, so I'll try to explain my reasoning here.  I've been bitten several times trying to manage the conda-installed redis.  Other "users" on the system don't know where to find it, system-level services don't know about it or how to manage it, and it's not guaranteed to work with whatever operating system it is installed on.  In summary, I don't think this is something we should try to be installing/running from userspace.  

Does somebody have a reason for keeping the redis install in conda besides "that's the way we're currently doing it"? 