### PR TITLE
Add pip as a proper dependency

### DIFF
--- a/salt/roots/salt/pip.sls
+++ b/salt/roots/salt/pip.sls
@@ -1,0 +1,3 @@
+pip:
+  pkg:
+    - installed

--- a/salt/roots/salt/top.sls
+++ b/salt/roots/salt/top.sls
@@ -5,6 +5,7 @@ base:
     - nginx
     - redis-server
     - git
+    - pip
     - silversearcher-ag
     - docker
     - tig


### PR DESCRIPTION
fixes to salty vagrant, partial fix for docker py issue.