### PR TITLE
revert shell=True in 734494, hardcode Java/PATHs

### DIFF
--- a/salt/roots/salt/memex-explorer.sls
+++ b/salt/roots/salt/memex-explorer.sls
@@ -80,6 +80,8 @@ celery:
     - name: /home/vagrant/miniconda/envs/memex/bin/celery --detach --loglevel=debug --logfile=/vagrant/source/celeryd.log --workdir="/vagrant/source" -A memex worker
     - cwd: /vagrant/source
     - user: vagrant
+    - env:
+        - JAVA_HOME: '/usr/lib/jvm/java-7-oracle'
     - creates: /vagrant/source/celeryd.pid
     - require:
         - sls: conda-memex


### PR DESCRIPTION
This enables crawls to be executed as celery tasks within the
Vagrant/Salt environment.