### PR TITLE
spin up ec2 machines with not a not all-open security group.

### DIFF
--- a/deploy/deploy_ec2.sh
+++ b/deploy/deploy_ec2.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 source activate memex_deploy
-GIT_BRANCH='production' HTPASSWD_PATH='XXX' AWS_ID='XXX' AWS_SECRET='XXX' python ec2-fabfile.py
+GIT_BRANCH='production' SECURITY_GROUP='memex-explorer-prod' HTPASSWD_PATH='XXX' AWS_ID='XXX' AWS_SECRET='XXX' python ec2-fabfile.py

--- a/deploy/ec2-fabfile.py
+++ b/deploy/ec2-fabfile.py
@@ -78,7 +78,7 @@ KEYNAME = "{}-memex-{}".format(AMI_ID,os.environ.get('USER', 'memex'))
 def create_box():
     old_ids = set(i.id for i in ec2.get_only_instances())
     machine = ec2.run_instances(AMI_ID, key_name=KEYNAME,
-        security_groups=['all-open',], instance_type='m3.2xlarge')
+        security_groups=[os.environ.get('SECURITY_GROUP', 'memex-explorer-prod'),], instance_type='m3.2xlarge')
     new_instance = [i for i in ec2.get_only_instances() if i.id not in old_ids][0]
     print(new_instance.id)
     while new_instance.state != u'running':


### PR DESCRIPTION
read the env variable SECURITY_GROUP to determine what security group to spin up the ec2 machines with.