### PR TITLE
Dynamic production/development settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,25 +10,39 @@ To setup your machine, you will need Anaconda or Miniconds installed. Miniconda 
 
 Clone the repository and `cd memex-explorer/source`. Run the following commands:
 ```
-$ ./app_setup.sh && source activate memex && supervisord
+$ ./app_setup.sh
+$ source activate memex
+$ supervisord
 ```
-These commands will set up your memex environment, prepare the application by creating the database, and run all of the necessary services for the application. If there are any problems with any of these commands, please report them as a github issue.
-
-
-To stop running the services, simply press `Ctrl-c`.
+These commands will set up your memex environment, prepare the application by creating the database, and run all of the necessary services for the application. If there are any problems with any of these commands, please report them as a [GitHub issue](https://github.com/memex-explorer/memex-explorer/issues).
 
 If you have already run the install script, simply run `supervisord` from the `memex-explorer/source` directory to restart all of the services.
 
-<!---
-The current recommended method for developing Memex Explorer locally is to run it in a [Vagrant](https://www.vagrantup.com/) environment using [VirtualBox](http://docs.vagrantup.com/v2/virtualbox).  After you have installed Vagrant and VirtualBox, run the following commands.
+The supervisord will start supervisord in the foreground, which will
+in turn ensure that all services associated with the core Memex
+Explorer environment are running.  To stop supervisord and the
+associated services, send an interrupt to the process with `Ctrl-c`.
+
+# Testing
+
+To run memex-explorer tests, use the following command from within an active environment:
+```
+$ py.test
+```
+
+# Building the Documentation
+The project documentation is written in [reStructuredText](http://docutils.sf.net/rst.html) and can be built using the popular [Sphinx](http://sphinx-doc.org/) tool.
 
 ```
-$ git clone https://github.com/memex-explorer/memex-explorer
-$ cd memex-explorer
-$ vagrant up
+$ cd docs
+$ make html
 ```
 
-The installation process for the virtual machine can take about an hour, depending on the speed of your Internet connection, as it builds and provisions the Memex Explorer system.  Once it is running, you should receive a message stating that Memex Explorer is running locally on port 8000, which you will then be able to access from your web browser.
+The documentation is then available within `build/html/index.html`
+
+# Administration
+
+To access the administration panel, navigate to http://localhost:8000/admin (or the equivalent deployed URL) after starting Memex Explorer. Here you will be able to view and make manual changes to the database.
 
 # Deploying
 
@@ -70,24 +84,3 @@ To connect to a instance given an IP address of 54.167.11.71, log in with the co
     ssh -i keys/ec2-54.167.11.71.pem vagrant@54.167.11.71
 
 After the setup script is done running, you will be able to access the application by entering the IP address into your browser.
--->
-# Testing
-
-To run memex-explorer tests, use the following command from within an active environment:
-```
-$ py.test
-```
-
-# Building the Documentation
-The project documentation is written in [reStructuredText](http://docutils.sf.net/rst.html) and can be built using the popular [Sphinx](http://sphinx-doc.org/) tool.
-
-```
-$ cd docs
-$ make html
-```
-
-The documentation is then available within `build/html/index.html`
-
-# Administration
-
-To access the administration panel, navigate to http://localhost:8000/admin (or the equivalent deployed URL) after starting Memex Explorer. Here you will be able to view and make manual changes to the database.

--- a/source/memex/common_settings.py
+++ b/source/memex/common_settings.py
@@ -1,0 +1,159 @@
+"""
+Common Django settings for memex explorer project (both dev and deploy)
+
+For more information on this file, see
+https://docs.djangoproject.com/en/1.7/topics/settings/
+
+For the full list of settings and their values, see
+https://docs.djangoproject.com/en/1.7/ref/settings/
+"""
+
+# Build paths inside the project like this: os.path.join(BASE_DIR, ...)
+import logging
+import os
+import sys
+
+from django.conf import global_settings
+
+from local_settings import *
+from supervisor_services import check_process_state
+
+BASE_DIR = os.path.dirname(os.path.dirname(__file__))
+
+# Quick-start development settings - unsuitable for production
+# See https://docs.djangoproject.com/en/1.7/howto/deployment/checklist/
+
+# SECURITY WARNING: keep the secret key used in production secret!
+SECRET_KEY = '0#t((zq66&3*87djaltu-pn34%0p!*v_332f2p!$2i)w5y17f8'
+
+# SECURITY WARNING: don't run with debug turned on in production!
+DEBUG = False
+TEMPLATE_DEBUG = False
+
+ALLOWED_HOSTS = []
+
+# Application definition
+
+INSTALLED_APPS = (
+    'django.contrib.admin',
+    'django.contrib.auth',
+    'django.contrib.contenttypes',
+    'django.contrib.sessions',
+    'django.contrib.messages',
+    'django.contrib.staticfiles',
+    'crispy_forms',
+    'base',
+    'task_manager',
+)
+
+EXPLORER_APPS = (
+    'crawl_space',
+)
+
+INSTALLED_APPS += tuple("apps.%s" % app for app in EXPLORER_APPS)
+
+MIDDLEWARE_CLASSES = (
+    'django.contrib.sessions.middleware.SessionMiddleware',
+    'django.middleware.common.CommonMiddleware',
+    'django.middleware.csrf.CsrfViewMiddleware',
+    'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
+    'django.contrib.messages.middleware.MessageMiddleware',
+    'django.middleware.clickjacking.XFrameOptionsMiddleware',
+)
+
+TEMPLATE_CONTEXT_PROCESSORS = global_settings.TEMPLATE_CONTEXT_PROCESSORS + (
+    "base.views.project_context_processor",
+)
+
+ROOT_URLCONF = 'memex.urls'
+
+WSGI_APPLICATION = 'memex.wsgi.application'
+
+
+# Database
+# https://docs.djangoproject.com/en/1.7/ref/settings/#databases
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': os.path.join(BASE_DIR, 'db.sqlite3'),
+    }
+}
+
+# Internationalization
+# https://docs.djangoproject.com/en/1.7/topics/i18n/
+
+LANGUAGE_CODE = 'en-us'
+
+TIME_ZONE = 'UTC'
+
+USE_I18N = True
+
+USE_L10N = True
+
+USE_TZ = True
+
+
+# Static files (CSS, JavaScript, Images)
+# https://docs.djangoproject.com/en/1.7/howto/static-files/
+
+STATIC_ROOT = os.path.join(BASE_DIR, 'base/static')
+
+STATIC_URL = '/static/'
+
+TEMPLATE_DIRS = [os.path.join(BASE_DIR, 'templates')]
+
+MEDIA_URL = '/resources/'
+
+CRISPY_TEMPLATE_PACK = 'bootstrap3'
+
+
+LOGGING = {
+    'version': 1,
+    'disable_existing_loggers': False,
+    'handlers': {
+        'file': {
+            'level': 'DEBUG',
+            'class': 'logging.FileHandler',
+            'filename': os.path.join(BASE_DIR, 'memex/logs/debug.log'),
+        },
+    },
+    'loggers': {
+        'django.request': {
+            'handlers': ['file'],
+            'level': 'DEBUG',
+            'propagate': True,
+        },
+    },
+}
+
+# Celery Config
+BROKER_URL = 'redis://localhost'
+CELERY_RESULT_BACKEND = 'redis://localhost'
+
+CELERY_TASK_SERIALIZER = 'pickle'
+CELERY_RESULT_SERIALIZER = 'pickle'
+CELERY_ACCEPT_CONTENT=['pickle']
+CELERY_TRACK_STARTED = True
+
+#These must be specified
+MEDIA_ROOT = None
+PROJECT_PATH = None
+EXTERNAL_APP_LOCATIONS = {}
+
+# Update this list if you add an external application
+EXTERNAL_APPS = ['celery',
+                 'ddt',
+                 'elasticsearch',
+                 'kibana',
+                 'logio-harvester',
+                 'logio-server',
+                 'redis',
+                 'tad',
+                 'tika']
+
+sys.stderr.write("[%d]: Querying supervisor for state of external applications\n" % (os.getpid()))
+READY_EXTERNAL_APPS = [app for app in EXTERNAL_APPS if check_process_state(app)]
+sys.stderr.write("[%d]: The following applications are ready %s\n" % (os.getpid(), str(READY_EXTERNAL_APPS)))
+

--- a/source/memex/common_settings.py
+++ b/source/memex/common_settings.py
@@ -142,8 +142,8 @@ MEDIA_ROOT = None
 PROJECT_PATH = None
 EXTERNAL_APP_LOCATIONS = {}
 
-# Update this list if you add an external application
-EXTERNAL_APPS = ['celery',
+# Update this set if you add an external application
+EXTERNAL_APPS = {'celery',
                  'ddt',
                  'elasticsearch',
                  'kibana',
@@ -151,9 +151,11 @@ EXTERNAL_APPS = ['celery',
                  'logio-server',
                  'redis',
                  'tad',
-                 'tika']
+                 'tika'}
 
 sys.stderr.write("[%d]: Querying supervisor for state of external applications\n" % (os.getpid()))
-READY_EXTERNAL_APPS = [app for app in EXTERNAL_APPS if check_process_state(app)]
-sys.stderr.write("[%d]: The following applications are ready %s\n" % (os.getpid(), str(READY_EXTERNAL_APPS)))
-
+READY_EXTERNAL_APPS = {app for app in EXTERNAL_APPS if check_process_state(app)}
+if READY_EXTERNAL_APPS:
+    sys.stderr.write("[%d]: The following applications are ready %s\n" % (os.getpid(), str(READY_EXTERNAL_APPS)))
+else:
+    sys.stderr.write("[%d]: Supervisord not running or no applications are running\n" % (os.getpid()))

--- a/source/memex/settings_files/deploy_settings.py
+++ b/source/memex/settings_files/deploy_settings.py
@@ -1,5 +1,5 @@
 """
-Django settings for memex project.
+Django settings for deploying memex project.
 
 For more information on this file, see
 https://docs.djangoproject.com/en/1.7/topics/settings/
@@ -8,142 +8,18 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/1.7/ref/settings/
 """
 
-# Build paths inside the project like this: os.path.join(BASE_DIR, ...)
-import os
-from local_settings import *
-BASE_DIR = os.path.dirname(os.path.dirname(__file__))
-
-
-# Quick-start development settings - unsuitable for production
-# See https://docs.djangoproject.com/en/1.7/howto/deployment/checklist/
+from common_settings import *
+HOSTNAME='explorer.continuum.io'
 
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = '0#t((zq66&3*87djaltu-pn34%0p!*v_332f2p!$2i)w5y17f8'
 
-# SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
-
-TEMPLATE_DEBUG = True
-
-ALLOWED_HOSTS = []
-
-
-# Application definition
-
-INSTALLED_APPS = (
-    'django.contrib.admin',
-    'django.contrib.auth',
-    'django.contrib.contenttypes',
-    'django.contrib.sessions',
-    'django.contrib.messages',
-    'django.contrib.staticfiles',
-    'crispy_forms',
-    'base',
-    'task_manager',
-)
-
-EXPLORER_APPS = (
-    'crawl_space',
-)
-
-INSTALLED_APPS += tuple("apps.%s" % app for app in EXPLORER_APPS)
-
-MIDDLEWARE_CLASSES = (
-    'django.contrib.sessions.middleware.SessionMiddleware',
-    'django.middleware.common.CommonMiddleware',
-    'django.middleware.csrf.CsrfViewMiddleware',
-    'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
-    'django.contrib.messages.middleware.MessageMiddleware',
-    'django.middleware.clickjacking.XFrameOptionsMiddleware',
-)
-
-from django.conf import global_settings
-
-TEMPLATE_CONTEXT_PROCESSORS = global_settings.TEMPLATE_CONTEXT_PROCESSORS + (
-    "base.views.project_context_processor",
-)
-
-ROOT_URLCONF = 'memex.urls'
-
-WSGI_APPLICATION = 'memex.wsgi.application'
-
-
-# Database
-# https://docs.djangoproject.com/en/1.7/ref/settings/#databases
-
-DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': os.path.join(BASE_DIR, 'db.sqlite3'),
-    }
-}
-
-# Internationalization
-# https://docs.djangoproject.com/en/1.7/topics/i18n/
-
-LANGUAGE_CODE = 'en-us'
-
-TIME_ZONE = 'UTC'
-
-USE_I18N = True
-
-USE_L10N = True
-
-USE_TZ = True
-
-
-# Static files (CSS, JavaScript, Images)
-# https://docs.djangoproject.com/en/1.7/howto/static-files/
-
-STATIC_ROOT = os.path.join(BASE_DIR, 'base/static')
-
-STATIC_URL = '/static/'
-
-TEMPLATE_DIRS = [os.path.join(BASE_DIR, 'templates')]
-
 MEDIA_ROOT = '/home/vagrant/resources'
-
-MEDIA_URL = '/resources/'
-
-CRISPY_TEMPLATE_PACK = 'bootstrap3'
-
 PROJECT_PATH = os.path.join(MEDIA_ROOT, "projects")
 
-# Logging
-import logging
-
-LOGGING = {
-    'version': 1,
-    'disable_existing_loggers': False,
-    'handlers': {
-        'file': {
-            'level': 'DEBUG',
-            'class': 'logging.FileHandler',
-            'filename': os.path.join(BASE_DIR, 'memex/logs/debug.log'),
-        },
-    },
-    'loggers': {
-        'django.request': {
-            'handlers': ['file'],
-            'level': 'DEBUG',
-            'propagate': True,
-        },
-    },
-}
-
-# Celery Config
-BROKER_URL = 'redis://localhost'
-CELERY_RESULT_BACKEND = 'redis://localhost'
-
-CELERY_TASK_SERIALIZER = 'pickle'
-CELERY_RESULT_SERIALIZER = 'pickle'
-CELERY_ACCEPT_CONTENT=['pickle']
-CELERY_TRACK_STARTED = True
 CELERYD_USER="vagrant"
 CELERYD_GROUP="vagrant"
 
-# Enable dockerize functionality
 DEPLOYMENT = True
 
 #Must match the urls given in deploy/nginx.conf

--- a/source/memex/settings_files/deploy_settings.py
+++ b/source/memex/settings_files/deploy_settings.py
@@ -8,6 +8,9 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/1.7/ref/settings/
 """
 
+import os
+import sys
+
 from common_settings import *
 HOSTNAME='explorer.continuum.io'
 
@@ -21,9 +24,25 @@ CELERYD_USER="vagrant"
 CELERYD_GROUP="vagrant"
 
 DEPLOYMENT = True
+# SECURITY - This should eventually be turned off in deployment
+DEBUG = True
 
 #Must match the urls given in deploy/nginx.conf
 EXTERNAL_APP_LOCATIONS = {
     'kibana': '/kibana/',
     'logio': '/logio/',
 }
+
+# A few more checks in deployment that services are running correctly
+
+REQUIRED_EXTERNAL_APPS = {'celery',
+                          'elasticsearch',
+                          'kibana',
+                          'redis',
+                          'tika'}
+
+# but celery imports settings.py too, so don't check if we're celery
+
+my_process = os.path.basename(sys.argv[0])
+if my_process != 'celery':
+    assert REQUIRED_EXTERNAL_APPS <= READY_EXTERNAL_APPS

--- a/source/memex/settings_files/dev_settings.py
+++ b/source/memex/settings_files/dev_settings.py
@@ -8,142 +8,19 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/1.7/ref/settings/
 """
 
-# Build paths inside the project like this: os.path.join(BASE_DIR, ...)
-import os
-from local_settings import *
-BASE_DIR = os.path.dirname(os.path.dirname(__file__))
-
-
-# Quick-start development settings - unsuitable for production
-# See https://docs.djangoproject.com/en/1.7/howto/deployment/checklist/
+from common_settings import *
 
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = '0#t((zq66&3*87djaltu-pn34%0p!*v_332f2p!$2i)w5y17f8'
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
-
 TEMPLATE_DEBUG = True
 
-ALLOWED_HOSTS = []
-
-
-# Application definition
-
-INSTALLED_APPS = (
-    'django.contrib.admin',
-    'django.contrib.auth',
-    'django.contrib.contenttypes',
-    'django.contrib.sessions',
-    'django.contrib.messages',
-    'django.contrib.staticfiles',
-    'crispy_forms',
-    'base',
-    'task_manager',
-    'debug_toolbar',
-)
-
-EXPLORER_APPS = (
-    'crawl_space',
-)
-
-INSTALLED_APPS += tuple("apps.%s" % app for app in EXPLORER_APPS)
-
-MIDDLEWARE_CLASSES = (
-    'django.contrib.sessions.middleware.SessionMiddleware',
-    'django.middleware.common.CommonMiddleware',
-    'django.middleware.csrf.CsrfViewMiddleware',
-    'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
-    'django.contrib.messages.middleware.MessageMiddleware',
-    'django.middleware.clickjacking.XFrameOptionsMiddleware',
-)
-
-from django.conf import global_settings
-
-TEMPLATE_CONTEXT_PROCESSORS = global_settings.TEMPLATE_CONTEXT_PROCESSORS + (
-    "base.views.project_context_processor",
-)
-
-ROOT_URLCONF = 'memex.urls'
-
-WSGI_APPLICATION = 'memex.wsgi.application'
-
-
-# Database
-# https://docs.djangoproject.com/en/1.7/ref/settings/#databases
-
-DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': os.path.join(BASE_DIR, 'db.sqlite3'),
-    }
-}
-
-# Internationalization
-# https://docs.djangoproject.com/en/1.7/topics/i18n/
-
-LANGUAGE_CODE = 'en-us'
-
-TIME_ZONE = 'UTC'
-
-USE_I18N = True
-
-USE_L10N = True
-
-USE_TZ = True
-
-
-# Static files (CSS, JavaScript, Images)
-# https://docs.djangoproject.com/en/1.7/howto/static-files/
-
-STATIC_ROOT = os.path.join(BASE_DIR, 'base/static')
-
-STATIC_URL = '/static/'
-
-TEMPLATE_DIRS = [os.path.join(BASE_DIR, 'templates')]
+INSTALLED_APPS += ('debug_toolbar',)
 
 MEDIA_ROOT = os.path.join(BASE_DIR, 'resources')
-
-MEDIA_URL = '/resources/'
-
-CRISPY_TEMPLATE_PACK = 'bootstrap3'
-
 PROJECT_PATH = os.path.join(MEDIA_ROOT, "projects")
-
-# Logging
-import logging
-
-LOGGING = {
-    'version': 1,
-    'disable_existing_loggers': False,
-    'handlers': {
-        'file': {
-            'level': 'DEBUG',
-            'class': 'logging.FileHandler',
-            'filename': os.path.join(BASE_DIR, 'memex/logs/debug.log'),
-        },
-    },
-    'loggers': {
-        'django.request': {
-            'handlers': ['file'],
-            'level': 'DEBUG',
-            'propagate': True,
-        },
-    },
-}
-
-# Celery Config
-BROKER_URL = 'redis://localhost'
-CELERY_RESULT_BACKEND = 'redis://localhost'
-
-CELERY_TASK_SERIALIZER = 'pickle'
-CELERY_RESULT_SERIALIZER = 'pickle'
-CELERY_ACCEPT_CONTENT=['pickle']
-CELERY_TRACK_STARTED = True
-
-
-# Disable dockerize functionality
 DEPLOYMENT = False
 
 EXTERNAL_APP_LOCATIONS = {

--- a/source/memex/supervisor_services.py
+++ b/source/memex/supervisor_services.py
@@ -2,8 +2,12 @@
 """
 
 import xmlrpclib
-import supervisor.xmlrpc
+import socket
 
 def check_process_state(process_name, state='RUNNING'):
     server = xmlrpclib.Server('http://localhost:9001/RPC2')
-    return server.supervisor.getProcessInfo(process_name)['statename'] == state
+    try:
+        response = server.supervisor.getProcessInfo(process_name)['statename'] == state
+    except socket.error:
+        response = None
+    return response

--- a/source/memex/supervisor_services.py
+++ b/source/memex/supervisor_services.py
@@ -1,0 +1,9 @@
+""" Module for querying supervisor for running/available services
+"""
+
+import xmlrpclib
+import supervisor.xmlrpc
+
+def check_process_state(process_name, state='RUNNING'):
+    server = xmlrpclib.Server('http://localhost:9001/RPC2')
+    return server.supervisor.getProcessInfo(process_name)['statename'] == state

--- a/source/resources/logs/README.md
+++ b/source/resources/logs/README.md
@@ -1,0 +1,3 @@
+This directory is where supervisor logfiles go by default
+
+It's recommended that you edit supervisord.conf to point elsewhere in production settings

--- a/source/supervisord.conf
+++ b/source/supervisord.conf
@@ -2,6 +2,7 @@
 username=cloud-user
 
 [supervisord]
+childlogdir=resources/logs
 logfile=supervisord.log ; (main log file;default $CWD/supervisord.log)
 logfile_maxbytes=50MB        ; (max main logfile bytes b4 rotation;default 50MB)
 logfile_backups=10           ; (num of main logfile rotation backups;default 10)
@@ -22,27 +23,39 @@ priority=1
 command=celery -A memex worker -l info
 priority=2
 
-[program:django]
-command=python manage.py runserver
-stopasgroup=true
-priority=3
-
 [program:elasticsearch]
 command=elasticsearch
-priority=4
+priority=1
 
 [program:tika]
 command=tika-rest-server
-priority=5
+priority=2
 
 [program:kibana]
 command=kibana
-priority=6
+priority=2
 
 [program:logio-server]
 command=log.io-server
-priority=7
+priority=1
 
 [program:logio-harvester]
 command=log.io-harvester
-priority=8
+priority=1
+
+[program:ddt]
+command=ddt
+priority=5
+autostart=false
+
+[program:tad]
+command=tad
+priority=5
+autostart=false
+
+[program:django]
+command=python manage.py runserver
+stopasgroup=true
+
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface


### PR DESCRIPTION
This PR makes the way for dynamic integration of loosely-coupled external applications such as TAD and DDT.  Instead of the microservice model, this uses a dynamic run-time test from the settings file to see what services are running (under supervisor's control) when Django is initiated.  This requires a tight coupling to supervisord, but if needed, "fake" processes with the same names can be created to provide the same running/stopped information to Django. 