### PR TITLE
Needs Review: Conditional Externals (DDT/TAD)

### DIFF
--- a/source/apps/crawl_space/templates/crawl_space/add_crawl_model.html
+++ b/source/apps/crawl_space/templates/crawl_space/add_crawl_model.html
@@ -18,7 +18,13 @@
             <h1>Add Crawl Model</h1>
             {% crispy form %}
         </div>
+        {% if "ddt" in settings.READY_EXTERNAL_APPS %}
+        <a id="DDT"
+           style="float:right;" class="btn btn-default btn-duo center link-button" href={{settings.EXTERNAL_APP_LOCATIONS.ddt}}> Domain Discovery
+        </a>
+        {% endif %}
     </div>
 </div>
+
 {% endblock %}
 

--- a/source/base/templates/base/project.html
+++ b/source/base/templates/base/project.html
@@ -48,6 +48,10 @@
             <a class="add_index btn btn-default btn-duo center link-button" href="{% url 'base:add_index' project_slug=project.slug %}">Add Dataset</a>
 
             <a class="btn btn-default btn-duo center link-button" href="{% url 'base:crawl_space:add_crawl_model' project_slug=project.slug %}">Add Crawl Model</a>
+
+              {% if "ddt" in settings.READY_EXTERNAL_APPS %}
+              <a class="btn btn-default btn-duo center link-button" href={{settings.EXTERNAL_APP_LOCATIONS.ddt}}>Domain Discovery </a>
+              {% endif %}
           </div>
 
     </div>

--- a/source/base/views.py
+++ b/source/base/views.py
@@ -33,6 +33,7 @@ from task_manager.file_tasks import upload_zip
 def project_context_processor(request):
     additional_context = {
         'projects': Project.objects.all(),
+        'settings': settings,
         'deployment': settings.DEPLOYMENT,
         'logio': settings.EXTERNAL_APP_LOCATIONS["logio"],
         'kibana': settings.EXTERNAL_APP_LOCATIONS["kibana"],

--- a/source/memex/settings_files/deploy_settings.py
+++ b/source/memex/settings_files/deploy_settings.py
@@ -29,6 +29,7 @@ DEBUG = True
 
 #Must match the urls given in deploy/nginx.conf
 EXTERNAL_APP_LOCATIONS = {
+    'ddt': 'http://explorer.continuum.io:8084',
     'kibana': '/kibana/',
     'logio': '/logio/',
 }

--- a/source/memex/settings_files/dev_settings.py
+++ b/source/memex/settings_files/dev_settings.py
@@ -24,6 +24,7 @@ PROJECT_PATH = os.path.join(MEDIA_ROOT, "projects")
 DEPLOYMENT = False
 
 EXTERNAL_APP_LOCATIONS = {
+    'ddt': 'http://localhost:8084',
     'kibana': 'http://localhost:5601',
     'logio': 'http://localhost:28778',
 }


### PR DESCRIPTION
This PR adds conditional display of outbound links to DDT when the DDT service is running.  This supercedes all other branches for DDT development and should be safe to go into mainline.

@brittainhard - There's a global change here in that I'd like to expose the entire settings module to templates, instead of piecemeal updating information that needs to go into templates.  I can revert this if you don't like it.